### PR TITLE
Fix download button, update OpenAI models, clean up dev files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,7 @@ __pycache__
 *.pyc
 tests/
 data_example/
-Untitled.ipynb
 short_script.py
-try_openai.py
 data.csv
 data_to_translate.csv
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # Development scripts
 short_script.py
-try_openai.py
 
 # Pycharm files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
     hooks:
     - id: mypy
       args: [--ignore-missing-imports, --warn-no-return, --warn-redundant-casts, --disallow-incomplete-defs, --no-namespace-packages ]
+      additional_dependencies: [numpy]
 -   repo: https://github.com/PyCQA/flake8
     rev: '7.3.0'
     hooks:

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,3 @@
 [server]
-enableCORS = false
+enableCORS = true
 enableXsrfProtection = true

--- a/pages/step_2_data_translate.py
+++ b/pages/step_2_data_translate.py
@@ -108,8 +108,17 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
 
             openai_model = st.selectbox(
                 'OpenAI model',
-                options=['gpt-4o-mini', 'gpt-4o', 'gpt-5.2'],
-                help='gpt-4o-mini is cheapest, gpt-5.2 is highest quality.',
+                options=[
+                    'gpt-4o-mini',
+                    'gpt-4o',
+                    'gpt-4.1-nano',
+                    'gpt-4.1-mini',
+                    'gpt-4.1',
+                    'gpt-5-nano',
+                    'gpt-5-mini',
+                    'gpt-5',
+                ],
+                help='Nano/mini variants are cheapest and fastest; full gpt-4.1 and gpt-5 give the highest quality.',
             )
 
             # Furigana option — only if Japanese data is present

--- a/src/utils.py
+++ b/src/utils.py
@@ -347,7 +347,12 @@ def estimate_openai_cost(n_words: int, model: str) -> str:
     costs_per_1m = {
         'gpt-4o-mini': {'input': 0.15, 'output': 0.60},
         'gpt-4o': {'input': 2.50, 'output': 10.00},
-        'gpt-5.2': {'input': 2.50, 'output': 10.00},
+        'gpt-4.1-nano': {'input': 0.10, 'output': 0.40},
+        'gpt-4.1-mini': {'input': 0.40, 'output': 1.60},
+        'gpt-4.1': {'input': 2.00, 'output': 8.00},
+        'gpt-5-nano': {'input': 0.05, 'output': 0.40},
+        'gpt-5-mini': {'input': 0.25, 'output': 2.00},
+        'gpt-5': {'input': 1.25, 'output': 10.00},
     }
     cost_info = costs_per_1m.get(model, costs_per_1m['gpt-4o-mini'])
     # With batching (10 words per call), tokens per word decrease


### PR DESCRIPTION
Pair enableCORS with enableXsrfProtection in .streamlit/config.toml so st.download_button returns the CSV instead of the app's HTML page.

Replace the non-existent 'gpt-5.2' option with the real current OpenAI API model IDs (gpt-4o, gpt-4.1 and gpt-5 families) and extend the cost table in estimate_openai_cost to cover them.

Delete the unused try_openai.py and Untitled.ipynb scratch files and drop their entries from .gitignore / .dockerignore.

Declare numpy as an additional dependency for the pre-commit mypy hook so its isolated env can load the numpy.typing plugin referenced in mypy.ini.