### PR TITLE
Fix sample data in Docker image and filter reset on dedup toggle

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 __pycache__
 *.pyc
 tests/
-data_example/
 short_script.py
 data.csv
 data_to_translate.csv

--- a/pages/step_2_data_translate.py
+++ b/pages/step_2_data_translate.py
@@ -14,12 +14,13 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
     initial_count = data.shape[0]
 
     with my_expander2:
+        st.caption('Filters are applied in the numbered order.')
         # limit the number of rows
         col1_, col2_ = st.columns(2)
         with col1_:
             top_n: int = int(
                 st.number_input(
-                    'Take last N rows',
+                    '1. Take last N rows',
                     min_value=1,
                     max_value=data.shape[0],
                     value=data.shape[0],
@@ -34,7 +35,7 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
         st.caption(f'After row limit: {data.shape[0]} rows (from {initial_count})')
 
         d = st.date_input(
-            label='Starting date',
+            label='2. Starting date',
             value=pd.to_datetime(data['Timestamp']).dt.date.min(),
             min_value=pd.to_datetime(data['Timestamp']).dt.date.min(),
             max_value=pd.to_datetime(data['Timestamp']).dt.date.max(),
@@ -44,13 +45,6 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
         data = data.loc[pd.to_datetime(data['Timestamp']).dt.date >= d]
         if data.shape[0] != before_date:
             st.caption(f'After date filter: {data.shape[0]} rows (removed {before_date - data.shape[0]})')
-
-        # Drop duplicate words
-        drop_dupes = st.checkbox('Drop duplicate words (keep last occurrence)', value=False)
-        if drop_dupes:
-            before_dupes = data.shape[0]
-            data = data.drop_duplicates('Word', keep='last')
-            st.caption(f'After dedup: {data.shape[0]} rows (removed {before_dupes - data.shape[0]} duplicates)')
 
         # select the target language
         langs_list = GoogleTranslator().get_supported_languages()
@@ -137,7 +131,7 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
         )
 
         books = st.multiselect(
-            label='Filter by books',
+            label='3. Filter by books',
             options=data['Book title'].unique(),
             default=data['Book title'].unique(),
             help='Select the books that will be translated',
@@ -149,7 +143,7 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
                 st.caption(f'After book filter: {data.shape[0]} rows (removed {before_books - data.shape[0]})')
 
         authors = st.multiselect(
-            label='Filter by authors',
+            label='4. Filter by authors',
             options=data['Authors'].unique(),
             default=data['Authors'].unique(),
             help='Select the Authors that will be translated',
@@ -161,7 +155,7 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
                 st.caption(f'After author filter: {data.shape[0]} rows (removed {before_authors - data.shape[0]})')
 
         langs_from = st.multiselect(
-            label='Languages to translate',
+            label='5. Languages to translate',
             options=data['Word language'].unique(),
             default=data['Word language'].unique(),
             help='Select the languages that will be translated',
@@ -171,6 +165,13 @@ if 'loaded_data' in st.session_state and st.session_state.loaded_data.shape[0] >
             data = data.loc[data['Word language'].isin(langs_from)]
             if data.shape[0] != before_langs:
                 st.caption(f'After language filter: {data.shape[0]} rows (removed {before_langs - data.shape[0]})')
+
+        # Applied last so toggling it does not change the options of the filters above
+        drop_dupes = st.checkbox('6. Drop duplicate words (keep last occurrence)', value=False)
+        if drop_dupes:
+            before_dupes = data.shape[0]
+            data = data.drop_duplicates('Word', keep='last')
+            st.caption(f'After dedup: {data.shape[0]} rows (removed {before_dupes - data.shape[0]} duplicates)')
 
         st.write(f'{data.shape[0]} texts will be translated (using {translation_backend})')
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 -r requirements.txt
-pytest==9.0.2
+pytest==9.1.1


### PR DESCRIPTION
## Summary
- **Sample data button fix**: `data_example/` was excluded by `.dockerignore`, so the deployed app raised `FileNotFoundError` when pressing "Press the button to use a sample data" on step 1. The directory is now included in the Docker image.
- **Filter reset fix (step 2)**: toggling "Drop duplicate words" changed the data feeding the book/author/language multiselect options, which changed the widgets' identity and reset the user's selections. The dedup is now applied *after* those filters, so toggling it preserves selections. Side benefit: dedup now operates within the filtered selection, so a word in a selected book can no longer be dropped in favor of a later occurrence in a filtered-out book.
- **UX**: filter widgets are numbered 1–6 in the order they are applied, with a caption explaining this. The dedup checkbox moved down next to the filters it follows.

## Test plan
- [x] Deployed image contains `data_example/example_data.csv`; sample data button loads data on step 1
- [x] On step 2, select a specific book, then toggle "Drop duplicate words" — book selection persists
- [x] Dedup row-count caption still shows removed duplicates; translate count reflects deduped data

Note: widget labels changed, so existing sessions will see filter selections reset once after deployment (one-time effect of renaming).